### PR TITLE
Changes to download correct version of buildtools nativesdk and use thud branch for meta-selinux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,6 +25,7 @@
 [submodule "layers/meta-selinux"]
 	path = layers/meta-selinux
 	url = https://github.com/MontaVista-OpenSourceTechnology/meta-selinux.git
+	branch = thud
 [submodule "layers/meta-security"]
 	path = layers/meta-security
 	url = https://github.com/MontaVista-OpenSourceTechnology/meta-security.git

--- a/default.xml
+++ b/default.xml
@@ -8,7 +8,7 @@
 	<project name="MontaVista-OpenSourceTechnology/meta-virtualization.git" remote="github.com" path="layers/meta-virtualization" revision="thud"/>
 	<project name="MontaVista-OpenSourceTechnology/meta-qa.git" remote="github.com" path="layers/meta-qa" revision="thud"/>
 	<project name="MontaVista-OpenSourceTechnology/meta-montavista-cgx.git" remote="github.com" path="layers/meta-montavista-cgx" revision="thud"/>
-	<project name="MontaVista-OpenSourceTechnology/meta-selinux.git" remote="github.com" path="layers/meta-selinux" revision="master"/>
+	<project name="MontaVista-OpenSourceTechnology/meta-selinux.git" remote="github.com" path="layers/meta-selinux" revision="thud"/>
 	<project name="MontaVista-OpenSourceTechnology/meta-security.git" remote="github.com" path="layers/meta-security" revision="thud"/>
 	<project name="MontaVista-OpenSourceTechnology/meta-cgl.git" remote="github.com" path="layers/meta-cgl" revision="master"/>
 	<project name="MontaVista-OpenSourceTechnology/meta-cloud-services.git" remote="github.com" path="layers/meta-cloud-services" revision="thud"/>

--- a/setup.sh
+++ b/setup.sh
@@ -46,7 +46,7 @@ LAYER@https://github.com/MontaVista-OpenSourceTechnology/meta-openembedded.git;b
 LAYER@https://github.com/MontaVista-OpenSourceTechnology/meta-openembedded.git;branch=thud;layer=meta-gnome \
 LAYER@https://github.com/MontaVista-OpenSourceTechnology/meta-openembedded.git;branch=thud;layer=meta-multimedia \
 LAYER@https://github.com/MontaVista-OpenSourceTechnology/meta-openembedded.git;branch=thud;layer=meta-xfce \
-LAYER@https://github.com/MontaVista-OpenSourceTechnology/meta-selinux.git;branch=master \
+LAYER@https://github.com/MontaVista-OpenSourceTechnology/meta-selinux.git;branch=thud \
 LAYER@https://github.com/MontaVista-OpenSourceTechnology/meta-security.git;branch=thud \
 LAYER@https://github.com/MontaVista-OpenSourceTechnology/meta-cgl.git;branch=master;layer=meta-cgl-common \
 LAYER@https://github.com/MontaVista-OpenSourceTechnology/meta-cloud-services.git;branch=thud \
@@ -57,7 +57,7 @@ MACHINE@qemuriscv64 \
 DISTRO@mvista-cgx \
 CONFIG@PREFERRED_PROVIDER_virtual/kernel=linux-riscv \
 "
-BUILD_TOOLS_LOCATION=http://downloads.yoctoproject.org/releases/yocto/yocto-2.3.3/buildtools/
+BUILD_TOOLS_LOCATION="$(lynx -dump http://downloads.yoctoproject.org/releases/yocto/ | grep yocto-2.6 | gawk -F " " '{print $2}' | tail -n 1)buildtools"
 TOPDIR=$(dirname $THIS_SCRIPT)
 buildtar=""
 URL=""


### PR DESCRIPTION
Source: MontaVista Software, LLC
MR: 00000
Type: Defect Fix
Disposition: Local
ChangeID: ea4feccc86ec1cf7038f87e54c4de0bd651e0da6
Description:

Using 2.6.x buildtools nativesdk installer solves below error,
-- snip --
Your system needs to support the en_US.UTF-8 locale
-- snip --

Check out thud branch of meta-selinux, it solves below error;
-- snip --
configure: error: unrecognized option: `-Dselinux=false'
Try `../glib-2.58.0/configure --help' for more information
NOTE:
ERROR: configure failed
-- snip --

Signed-off-by: Jagadeesh Krishnanjanappa <jkrishnanjanappa@mvista.com>